### PR TITLE
Fix Spark Parquet read path

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -81,7 +81,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
     List<Types.NestedField> expectedFields = struct.fields();
     for (int i = 0; i < expectedFields.size(); i += 1) {
       Types.NestedField field = expectedFields.get(i);
-      String sanitizedFieldName = AvroSchemaUtil.sanitize(field.name());
+      String sanitizedFieldName = AvroSchemaUtil.makeCompatibleName(field.name());
 
       // detect reordering
       if (i < fields.size() && !sanitizedFieldName.equals(fields.get(i).name())) {
@@ -124,7 +124,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
       return null;
     }
 
-    String expectedName = AvroSchemaUtil.sanitize(expectedField.name());
+    String expectedName = AvroSchemaUtil.makeCompatibleName(expectedField.name());
 
     this.current = expectedField.type();
     try {

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -67,6 +67,11 @@ public class SparkParquetReaders {
   private SparkParquetReaders() {
   }
 
+  public static ParquetValueReader<InternalRow> buildReader(Schema expectedSchema,
+                                                            MessageType fileSchema) {
+    return SparkParquetReaders.buildReader(expectedSchema, fileSchema, Collections.emptyMap());
+  }
+
   @SuppressWarnings("unchecked")
   public static ParquetValueReader<InternalRow> buildReader(Schema expectedSchema,
                                                             MessageType fileSchema,
@@ -80,11 +85,6 @@ public class SparkParquetReaders {
           TypeWithSchemaVisitor.visit(expectedSchema.asStruct(), fileSchema,
               new FallbackReadBuilder(fileSchema, partitionValues));
     }
-  }
-
-  public static ParquetValueReader<InternalRow> buildReader(Schema expectedSchema,
-                                                            MessageType fileSchema) {
-    return SparkParquetReaders.buildReader(expectedSchema, fileSchema, Collections.emptyMap());
   }
 
   private static class FallbackReadBuilder extends ReadBuilder {


### PR DESCRIPTION
This moves partition map building to a separate method and fixes schema handling.